### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,13 +7,13 @@ class ItemsController < ApplicationController
     @items = Item.all.order('created_at DESC')
   end
 
-  def show
-    @item = Item.find(params[:id])
-  end
-
   # 出品ページ（入力フォーム）を表示する
   def new
     @item = Item.new
+  end
+
+  def edit
+    @item = Item.find(params[:id])
   end
 
   # 必要な情報を正しく入力して「出品する」ボタンを押すと、商品情報がデータベースに保存されること

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,54 +1,62 @@
 class ItemsController < ApplicationController
-  # ログイン状態の場合のみ、商品出品ページへ移行できること
-  # ログアウト状態の場合は、商品出品ページへ移行しようとすると、ログインページへ移行すること
-  before_action :authenticate_user!, only: [:new, :create]
+  # 1. 共通処理をアクションの実行前に呼び出す
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show, :edit, :update]  
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
   end
 
   def show
-    @item = Item.find(params[:id])
+    # before_actionで@itemがセットされるため空でOK
   end
 
-  # 出品ページ（入力フォーム）を表示する
   def new
     @item = Item.new
   end
 
   def edit
-    @item = Item.find(params[:id])
+    # before_actionで@itemがセットされ、move_to_indexで出品者チェックも済んでいるため空でOK
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
+      # エラーがある場合は編集画面を再表示（statusを指定してRails 7以降の挙動に対応）
       render :edit, status: :unprocessable_entity
     end
   end
 
-  # 必要な情報を正しく入力して「出品する」ボタンを押すと、商品情報がデータベースに保存されること
-  # 出品が完了したら、トップページに進むこと
-  # エラーハンドリングができること（入力に問題がある状態で「出品する」ボタンが押された場合、情報は保存されず、出品ページに返品エラーメッセージが表示されること）
   def create
     @item = Item.new(item_params)
     if @item.save
       redirect_to root_path
     else
-      # 失敗したとき、エラーを持って出品ページを表示し直す
       render :new, status: :unprocessable_entity
     end
   end
 
   private
 
-  # ストロングパラメーターの設定
+  # ストロングパラメーター
   def item_params
     params.require(:item).permit(
       :image, :name, :info, :category_id, :sales_status_id,
       :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price
     ).merge(user_id: current_user.id)
+  end
+
+  # 特定の商品を1箇所で取得する設定
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  # 出品者以外をトップページへ戻す設定
+  def move_to_index
+    unless current_user.id == @item.user_id
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,10 @@ class ItemsController < ApplicationController
     @items = Item.all.order('created_at DESC')
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   # 出品ページ（入力フォーム）を表示する
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,15 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   # 必要な情報を正しく入力して「出品する」ボタンを押すと、商品情報がデータベースに保存されること
   # 出品が完了したら、トップページに進むこと
   # エラーハンドリングができること（入力に問題がある状態で「出品する」ボタンが押された場合、情報は保存されず、出品ページに返品エラーメッセージが表示されること）

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   # 1. 共通処理をアクションの実行前に呼び出す
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]  
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :move_to_index, only: [:edit, :update]
 
   def index
@@ -55,8 +55,8 @@ class ItemsController < ApplicationController
 
   # 出品者以外をトップページへ戻す設定
   def move_to_index
-    unless current_user.id == @item.user_id
-      redirect_to root_path
-    end
+    return if current_user.id == @item.user_id
+
+    redirect_to root_path
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
-
+     <%= render 'shared/error_messages', model: f.object %>
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -32,7 +32,7 @@ app/assets/stylesheets/items/new.css %>
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :name, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :info, class:"items-text", id:"item-info", placeholder:"商品の説明...", rows:"7", maxlength:"1000" %>
       </div>
     </div>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,4 +1,3 @@
-app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -125,7 +124,7 @@ app/assets/stylesheets/items/new.css %>
 
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
 
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -6,7 +6,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -17,7 +17,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
 
@@ -26,13 +26,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :name, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
 
@@ -43,12 +43,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:sales_status_id, SalesStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
 
@@ -62,17 +62,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
 
@@ -88,7 +88,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,7 +19,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: "items#index"
 
   # 商品に関するルート（index, new, create）をまとめて定義します
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: "items#index"
 
   # 商品に関するルート（index, new, create）をまとめて定義します
-  resources :items, only: [:index, :new, :create, :show, :edit]
+  resources :items, only: [:index, :new, :create, :show, :edit,:update]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
What: 商品情報の編集・更新機能の実装、および発生していたエラーの修正。  

Why: ユーザーが自身の商品を安全かつ正確に編集できるようにするため。

ログイン状態の出品者は、商品情報編集ページに移行できる動画
https://gyazo.com/d61f9303c4edd0edaccbfc215d7d7a61

必要な情報を正しく入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/66bc5e1f6d70d4aebc89e78e33ab2568

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻るエラーメッセージが表示される動画
https://gyazo.com/c219bcc6bf37832b87198e71e87fc509

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/dbdfb10006c6c61e01d24121095323fd

ログイン状態の場合でも、URLを直接入力して自分が出品していない商品の商品情報編集ページへ移行しようとすると、商品の販売状況に不利ずトップページに移行する動画
https://gyazo.com/705275407bfb4b3ead46cc523d5368b1

ログイン状態の場合でも、URLを直接入力して自分が出品した販売済み商品の商品情報編集ページへ移行しようとすると、トップページに移行する動画（現段階で商品購入機能の実装が済んでいる場合）
現段階で商品購入機能の実装が済でない

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ移行しようとすると、商品の販売状況に不利ずログインページに移行する動画
https://gyazo.com/fad929c401ecaf32cbad3415fd072d10

商品名やカテゴリーの情報など、既に登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/7ba6131288a4733f1a73970a95a932fd

<img width="1504" height="288" alt="image" src="https://github.com/user-attachments/assets/c5a7841e-9e7a-4a7d-a48d-5a902c313849" />
